### PR TITLE
Make asar-require work under Node 2.3+

### DIFF
--- a/src/require.coffee
+++ b/src/require.coffee
@@ -1,6 +1,10 @@
 asar = require 'asar'
 fs   = require 'fs'
 path = require 'path'
+try
+  node_module = require 'module'
+catch error
+  node_module = null
 
 # Separate asar package's path from full path.
 splitPath = (p) ->
@@ -71,3 +75,11 @@ fs.realpathSync = (p) ->
   stat = asar.statFile(asarPath, filePath)
   filePath = stat.link if stat.link
   path.join realpathSync(asarPath), filePath
+
+if node_module and node_module._findPath
+  module_findPath = node_module._findPath
+
+  node_module._findPath = (request, paths, isMain) ->
+    [isAsar, asarPath, filePath] = splitPath request
+    return module_findPath.apply this, arguments unless isAsar
+    request


### PR DESCRIPTION
Since version 2.3 node has switched to the internal implementation of
"stat" [1], so the hooks no longer work.  Fix that.

[1] https://github.com/nodejs/node/pull/1801/commits/b14fd1a7202cd8001d1f6aed848445bad99ee15c#diff-d1234a869b3d648ebfcdce5a76747d71
[2] https://bugs.gentoo.org/show_bug.cgi?id=584000
